### PR TITLE
Fix: dotnet tool install fails on Apple Silicon (osx-arm64)

### DIFF
--- a/src/Elmah.Io.Cli/Elmah.Io.Cli.csproj
+++ b/src/Elmah.Io.Cli/Elmah.Io.Cli.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>elmahio</AssemblyName>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <Platforms>x64</Platforms>
     <ApplicationIcon>..\..\logo.ico</ApplicationIcon>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Problem

`dotnet tool install --global Elmah.Io.Cli` fails on Apple Silicon with:

```
Version 5.3.97 of package elmah.io.cli.osx-arm64 is not found in NuGet feeds
```

## Root cause

`<RuntimeIdentifiers>` in `Elmah.Io.Cli.csproj` causes `dotnet tool install` to look for separate RID-specific NuGet packages (e.g. `elmah.io.cli.osx-arm64`). Those packages don't exist on NuGet, so the install fails entirely on Apple Silicon.

## Fix

Remove `<RuntimeIdentifiers>` from the project file. The CI publish steps already pass `--runtime` per-platform via the command line, so the self-contained binary builds and release assets are unaffected. The global tool NuGet package will now be framework-dependent and install correctly on all platforms via `dotnet tool install --global Elmah.Io.Cli`.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)